### PR TITLE
Primary keys must not be NULL

### DIFF
--- a/islandora_xquery.install
+++ b/islandora_xquery.install
@@ -95,6 +95,7 @@ function islandora_xquery_schema() {
       'id' => array(
         'description' => "Unique ID",
         'type' => 'serial',
+        'not null' => TRUE,
         'unsigned' => TRUE,
       ),
       'batch_id' => array(


### PR DESCRIPTION
Was receiving `SQLSTATE 42000` errors when enabling the module... This line hasn't been touched in 5 years so I'm not exactly sure how this is just becoming an issue now?

Anyway this fixed the problem!