### PR TITLE
Add ability to process batch with drush

### DIFF
--- a/includes/apply.inc
+++ b/includes/apply.inc
@@ -42,7 +42,7 @@ function islandora_xquery_apply_results($batch_id) {
  * @param array $context
  *   The batch context.
  */
-function islandora_xquery_apply_query_batch_operation($batch_id, array &$context) {
+function islandora_xquery_apply_query_batch_operation($batch_id, &$context) {
   module_load_include('inc', 'islandora_object_lock', 'includes/utilities');
 
   if (!isset($context['sandbox']['progress'])) {

--- a/includes/apply.inc
+++ b/includes/apply.inc
@@ -22,7 +22,7 @@ function islandora_xquery_apply_results($batch_id) {
     'operations' => array(
       array(
         'islandora_xquery_apply_query_batch_operation',
-        array($batch_id),
+        array($batch_id, 'is_backend' => FALSE),
       ),
     ),
   ));
@@ -39,10 +39,12 @@ function islandora_xquery_apply_results($batch_id) {
  *
  * @param int $batch_id
  *   Identifier for the batch that previously ran the xquery.
+ * @param bool $is_backend
+ *   Whether the batch is being run by drush on the backend.
  * @param array $context
  *   The batch context.
  */
-function islandora_xquery_apply_query_batch_operation($batch_id, &$context) {
+function islandora_xquery_apply_query_batch_operation($batch_id, $is_backend, &$context) {
   module_load_include('inc', 'islandora_object_lock', 'includes/utilities');
 
   if (!isset($context['sandbox']['progress'])) {
@@ -50,8 +52,10 @@ function islandora_xquery_apply_query_batch_operation($batch_id, &$context) {
     $context['sandbox']['progress'] = 0;
     $context['sandbox']['total'] = islandora_xquery_apply_query_batch_get_total($batch_id);
 
-    // Jam the batch id into the results array for later use.
+    // Jam the batch id and is_backend flag
+    // into the results array for later use.
     $context['results']['batch_id'] = $batch_id;
+    $context['results']['is_backend'] = $is_backend;
 
     // Avoid divide by zero.
     if ($context['sandbox']['total'] == 0) {
@@ -235,5 +239,5 @@ function islandora_xquery_apply_query_batch_finished($success, $results, $operat
     drupal_set_message(filter_xss($output));
   }
   // Delete all appropriate db records and redirect.
-  islandora_xquery_cancel_results($results['batch_id']);
+  islandora_xquery_cancel_results($results['batch_id'], !$results['is_backend']);
 }

--- a/includes/apply.inc
+++ b/includes/apply.inc
@@ -104,6 +104,7 @@ function islandora_xquery_apply_query_batch_operation($batch_id, &$context) {
     }
     islandora_object_lock_set_object_lock($result->pid);
     islandora_xquery_apply_query_batch_apply_diff($result, $context);
+    islandora_xquery_remove_object_lock($fedora_object);
   }
 
   $context['results']['ignored_objects'] = $ignored_objects;
@@ -166,10 +167,6 @@ function islandora_xquery_apply_query_batch_apply_diff($result, &$context) {
   // Exit early if datastream update fails.
   try {
     $datastream->setContentFromString($new);
-    if (module_exists('islandora_object_lock')) {
-      module_load_include('inc', 'islandora_object_lock', 'includes/utilities');
-      islandora_object_lock_remove_object_lock($result->pid);
-    }
   }
   catch (Exception $e) {
     islandora_xquery_apply_query_batch_update_progress($result, ISLANDORA_XQUERY_STATUS_DATSTREAM_UPDATE_FAIL, $context);
@@ -200,6 +197,21 @@ function islandora_xquery_apply_query_batch_update_progress($result, $status, &$
   // Update progress.
   $context['sandbox']['progress']++;
   $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['total'];
+}
+
+/**
+ * Removes the object lock if it is set.
+ *
+ * @param AbstractObject $object
+ *   The fedora object.
+ */
+function islandora_xquery_remove_object_lock(AbstractObject $object) {
+  if (module_exists('islandora_object_lock')) {
+    module_load_include('inc', 'islandora_object_lock', 'includes/utilities');
+    if (islandora_object_lock_is_locked($object)) {
+      islandora_object_lock_remove_object_lock($object->id);
+    }
+  }
 }
 
 /**

--- a/includes/cancel.inc
+++ b/includes/cancel.inc
@@ -10,14 +10,18 @@
  *
  * @param int $batch_id
  *   Identifier for the batch that ran the xquery.
+ * @param bool $http_redirect
+ *   Whether to issue an HTTP redirect after cancelling pending results.
  */
-function islandora_xquery_cancel_results($batch_id) {
+function islandora_xquery_cancel_results($batch_id, $http_redirect = TRUE) {
   // Get the redirect url.
-  $redirect = db_select('islandora_xquery_batches', 'batches')
-    ->fields('batches', array('redirect'))
-    ->condition('batch_id', $batch_id, '=')
-    ->execute()
-    ->fetchField();
+  if ($http_redirect) {
+    $redirect = db_select('islandora_xquery_batches', 'batches')
+      ->fields('batches', array('redirect'))
+      ->condition('batch_id', $batch_id, '=')
+      ->execute()
+      ->fetchField();
+  }
 
   // Clear out the db.
   db_delete('islandora_xquery_diffs')
@@ -29,6 +33,8 @@ function islandora_xquery_cancel_results($batch_id) {
     ->execute();
 
   // Redirect.
-  $url = drupal_parse_url($redirect);
-  drupal_goto($url['path'], $url);
+  if ($http_redirect) {
+    $url = drupal_parse_url($redirect);
+    drupal_goto($url['path'], $url);
+  }
 }

--- a/includes/general_admin.form.inc
+++ b/includes/general_admin.form.inc
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Processor admin form.
+ */
+
+/**
+ * Form building function.
+ */
+function islandora_xquery_general_admin_form(array $form, array &$form_state) {
+  $form['islandora_xquery_show_batch_id'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Show batch ID'),
+    '#default_value' => variable_get('islandora_xquery_show_batch_id', FALSE),
+    '#description' => t('Show the batch ID when previewing XQuery results.'),
+  );
+  return system_settings_form($form);
+}

--- a/islandora_xquery.drush.inc
+++ b/islandora_xquery.drush.inc
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Drush helpers for Islandora XQuery.
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function islandora_xquery_drush_command() {
+  $commands = array();
+  $commands['islandora_xquery_batch_process'] = array(
+    'description' => dt('Process an Islandora XQuery batch set.'),
+    'options' => array(
+      'batch_id' => array(
+        'description' => dt('The batch set ID to process.'),
+        'required' => TRUE,
+      ),
+    ),
+    'aliases' => array('ixbp'),
+  );
+  return $commands;
+}
+
+/**
+ * Command callback for processing XQuery batches.
+ */
+function drush_islandora_xquery_batch_process() {
+  module_load_include('inc', 'islandora_xquery', 'includes/apply');
+
+  // @XXX: Standard logged-in-user paranoia.
+  drupal_static_reset('islandora_get_tuque_connection');
+  $connection = islandora_get_tuque_connection();
+
+  $batch_id = drush_get_option('batch_id');
+  $batch = array(
+    'title' => t('Applying XQuery'),
+    'finished' => 'islandora_xquery_apply_query_batch_finished',
+    'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining @estimate.'),
+    'error_message' => t('An error has occurred.'),
+    'file' => drupal_get_path('module', 'islandora_xquery') . '/includes/apply.inc',
+    'operations' => array(
+      array(
+        'islandora_xquery_apply_query_batch_operation',
+        array($batch_id),
+      ),
+    ),
+  );
+  batch_set($batch);
+  drush_backend_batch_process();
+
+}

--- a/islandora_xquery.drush.inc
+++ b/islandora_xquery.drush.inc
@@ -10,7 +10,7 @@
  */
 function islandora_xquery_drush_command() {
   $commands = array();
-  $commands['islandora_xquery_batch_process'] = array(
+  $commands['islandora_xquery_batch_process_command'] = array(
     'description' => dt('Process an Islandora XQuery batch set.'),
     'options' => array(
       'batch_id' => array(
@@ -26,7 +26,7 @@ function islandora_xquery_drush_command() {
 /**
  * Command callback for processing XQuery batches.
  */
-function drush_islandora_xquery_batch_process() {
+function drush_islandora_xquery_batch_process_command() {
   module_load_include('inc', 'islandora_xquery', 'includes/apply');
 
   // @XXX: Standard logged-in-user paranoia.

--- a/islandora_xquery.drush.inc
+++ b/islandora_xquery.drush.inc
@@ -43,7 +43,7 @@ function drush_islandora_xquery_batch_process() {
     'operations' => array(
       array(
         'islandora_xquery_apply_query_batch_operation',
-        array($batch_id),
+        array($batch_id, 'is_backend' => TRUE),
       ),
     ),
   );

--- a/islandora_xquery.module
+++ b/islandora_xquery.module
@@ -41,6 +41,15 @@ function islandora_xquery_menu() {
     'type' => MENU_DEFAULT_LOCAL_TASK,
     'weight' => -1,
   );
+  $items['admin/islandora/tools/xquery/manage/general'] = array(
+    'title' => 'General',
+    'description' => 'General configuration Islandora XQuery',
+    'access arguments' => array('administer islandora_xquery'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('islandora_xquery_general_admin_form'),
+    'file' => 'includes/general_admin.form.inc',
+    'type' => MENU_LOCAL_TASK,
+  );
   $items['admin/islandora/tools/xquery/manage/processor'] = array(
     'title' => 'Processors',
     'description' => 'Configure Islandora XQuery processor',

--- a/resources/install_islandora_xquery.sh
+++ b/resources/install_islandora_xquery.sh
@@ -20,7 +20,8 @@ rm -rf libxdiff-0.23
 
 # Add the xdiff extension to php configuration
 echo "extension=xdiff.so" > xdiff.ini
-sudo cp xdiff.ini /etc/php5/conf.d
+sudo cp xdiff.ini /etc/php5/mods-available/
+sudo php5enmod xdiff
 rm xdiff.ini
 
 # Restart apache so extension kicks in

--- a/theme/islandora-xquery-preview.tpl.php
+++ b/theme/islandora-xquery-preview.tpl.php
@@ -6,6 +6,11 @@
 ?>
 
 <div class="islandora-xquery-preview">
+  <?php if(variable_get('islandora_xquery_show_batch_id', FALSE)): ?>
+    <div class="islandora-xquery-batch-id">
+      <p><?php print "Batch ID: " . $batch_id?></p>
+    </div>
+  <?php endif ?>
   <div class="islandora-xquery-preview-controls">
     <ul class="islandora-xquery-preview-control-list">
       <li class="islandora-xquery-preview-control-li"><?php print islandora_xquery_get_apply_link($batch_id); ?></li>


### PR DESCRIPTION
* Allow the batch ID to be printed on the preview page when generating an xquery. And configuration to toggle this on/off.
* Add drush command to run xquery batch sets from the command line
* Fixed the install script because the xdiff extension wasn't being installed in a way that was available to drush
* Fixed a bug around removing the object lock when the process finishes
* Added an `is_backend` flag so we're not calling `drupal_goto` when running the batch from drush